### PR TITLE
making run specific elm make only work again

### DIFF
--- a/constant_testing
+++ b/constant_testing
@@ -109,8 +109,15 @@ clear_screen() {
 watch() {
   clear_screen
   if [ $FIXED_FILE ]; then
-    log_info "I'll run this for you now so you can see how broken it is before you start hacking about"
-    mix_test "$test_path"
+    if [[ "$test_path" = *.exs ]]; then
+      log_info "I'll run this for you now so you can see how broken it is before you start hacking about"
+      mix_test "$test_path"
+    elif [[ "$test_path" = *Main.elm ]]; then
+      log_info "I'll run this for you now so you can see how broken it is before you start hacking about"
+      elm_make $test_path
+    else
+      log_failure "I need an exs or Main.elm file to work mate..."
+    fi
   else
     log_info "I'm going to watch you work... in a creepy way"
   fi


### PR DESCRIPTION
now running 
`constant testing /path/to/elm/Main.elm`

will correctly run 
`elm make /path/to/elm/Main.elm`
initially (before any file saves are observed)..
and then fun the same command again if any files are changed