### PR TITLE
Elm test and run last

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Run this in your elixir project (or at the root of your umbrella project) and wh
   ```shell
   git clone https://github.com/danturn/constant_testing.git
   ```
-  
+
 2. Set it up wherever you want it
   ```shell
   cd constant_testing
@@ -22,3 +22,25 @@ Run this in your elixir project (or at the root of your umbrella project) and wh
   ```
 
 4. Start writing code!
+
+
+### Usage Varients
+
+1. `constant_testing`
+if a `*.exs` or `*.ex` file is saved, then
+`mix test /path/to/the/relevant/file.exs`
+will be run, with the path being worked-out from whichever path was saved.
+if an *.elm file is saved, then it'll try and find a corresponding Main.elm file and run
+`elm make /path/to/the/found/elm/Main.elm`
+
+2. `constant_testing /path/to/a/specific/elixir/test.exs`
+regardless of what `.ex` or `.exs` files are saved, will run
+`mix test /path/to/a/specific/elixir/text.exs`
+
+3. `constant_testing /path/to/a/specific/Main.elm`
+regardless of what `.elm` file is saved, will run
+`elm make /path/to/a/specific/Main.elm`
+
+4. `constant_testing --elm-analyse`
+regardless of what `.elm` file is saved, will run
+`yarn --cwd assets run elm-analyse`

--- a/README.md
+++ b/README.md
@@ -43,4 +43,4 @@ regardless of what `.elm` file is saved, will run
 
 4. `constant_testing --elm-test`
 regardless of what `.elm` file is saved, will run
-`yarn --cwd assets run elm-test`
+`elm-test`

--- a/README.md
+++ b/README.md
@@ -41,6 +41,6 @@ regardless of what `.ex` or `.exs` files are saved, will run
 regardless of what `.elm` file is saved, will run
 `elm make /path/to/a/specific/Main.elm`
 
-4. `constant_testing --elm-analyse`
+4. `constant_testing --elm-test`
 regardless of what `.elm` file is saved, will run
-`yarn --cwd assets run elm-analyse`
+`yarn --cwd assets run elm-test`

--- a/constant_testing
+++ b/constant_testing
@@ -49,6 +49,10 @@ find_elm_json() {
   echo $(dirname $json_dir)
 }
 
+find_first_elm_json() {
+  echo `find -name elm.json -print -quit`
+}
+
 real_readlink() {
   python -c "import os,sys;print os.path.realpath(\"$1\")"
 }
@@ -102,8 +106,16 @@ clear_screen() {
   tput reset
 }
 
+elm_test_command() {
+  echo "elm-test"
+}
+
 elm_test() {
-  run_command "yarn --cwd assets run elm-test" "Your elm tests passed! First time for everything..." "Your elm is riddled with bugs... (at least you have tests(s) though)..." true
+  elm_json_path=$(find_first_elm_json)
+  elm_json_dir=$(dirname $elm_json_path)
+  pushd $elm_json_dir > /dev/null
+  run_command $(elm_test_command) "Your elm tests passed! First time for everything..." "Your elm is riddled with bugs... (at least you have tests(s) though)..." true
+  popd > /dev/null
 }
 
 run_command() {
@@ -126,8 +138,13 @@ run_command() {
 }
 
 run_last_cmd() {
-  log_info "I don't know what to do with the file you just saved, so I'll just run the last thing I did again..."
-  run_command "$last_run_cmd" "Looks like everything is ok?" "It totally wrecked..." true
+  if [[ $last_run_cmd = $(elm_test_command) ]]; then
+    log_info "I don't know what to do with the file you just saved, so I'll just run the last thing I did again..."
+    elm_test
+  else
+    log_info "I don't know what to do with the file you just saved, so I'll just run the last thing I did again..."
+    run_command "$last_run_cmd" "Looks like everything is ok?" "It totally wrecked..." true
+  fi
 }
 
 watch() {

--- a/constant_testing
+++ b/constant_testing
@@ -1,15 +1,7 @@
 #!/bin/bash
 
 mix_test() {
-  log_info "Running: mix test $1"
-  output=`mix test $1 --color`
-  result=$?
-  echo "$output"
-  if [[ $result != 0 ]]; then
-    log_failure "OOOPPPPSIE - Somewhat predictably, you've broken something"
-  else
-    log_success "Congratulations, you haven't broken anything... yet..."
-  fi
+  run_command "mix test $1 --color" "Congratulations, you haven't broken anything... yet..." "OOOPPPPSIE - Somewhat predictably, you've broken something"
 }
 
 log_info() {
@@ -112,30 +104,35 @@ clear_screen() {
 
 elm_analyse() {
   log_info "Let's see how non compliant your elm is mate..."
-  elm_analyse_cmd="yarn --cwd assets run elm-analyse"
-  log_info "Running: $elm_analyse_cmd"
-  output=`$elm_analyse_cmd`
-  result=$?
-  echo "$output"
-  if [[ $result != 0 ]]; then
-    log_failure "Your elm is totally non compliant. What is this amateur hour?"
-  else
-    log_success "Much like a million monkeys at a typewriter will eventually write Shakespeare, your elm has lucked its way to being compliant. You're the best..."
-  fi
+  run_command "yarn --cwd assets run elm-analyse" "Much like a million monkeys at a typewriter will eventually write Shakespeare, your elm has lucked its way to being compliant. You're the best..." "Your elm is totally non compliant. What is this amateur hour?" true
 }
 
 elm_test() {
-  log_info "Let's run the elm tests..."
-  elm_test_cmd="yarn --cwd assets run elm-test"
-  log_info "Running: $elm_test_cmd"
-  output=`$elm_test_cmd`
+  run_command "yarn --cwd assets run elm-test" "Your elm tests passed! First time for everything..." "Your elm is riddled with bugs... (at least you have tests(s) though)..." true
+}
+
+run_command() {
+  cmd="$1"
+  success_message="$2"
+  failure_message="$3"
+  echo_output=$4
+  log_info "Running: $cmd"
+  output=`$cmd`
   result=$?
-  echo "$output"
-  if [[ $result != 0 ]]; then
-    log_failure "Your elm is riddled with bugs... (at least you have tests(s) though)..."
-  else
-    log_success "Your elm tests passed! First time for everything..."
+  last_run_cmd=$cmd
+  if [[ $echo_output = true ]]; then
+    echo "$output"
   fi
+  if [[ $result != 0 ]]; then
+    log_failure "$failure_message"
+  else
+    log_success "$success_message"
+  fi
+}
+
+run_last_cmd() {
+  log_info "I don't know what to do with the file you just saved, so I'll just run the last thing I did again..."
+  run_command "$last_run_cmd" "Looks like everything is ok?" "It totally wrecked..."
 }
 
 watch() {
@@ -191,6 +188,10 @@ watch() {
             log_info "No Main.elm found for $path"
           fi
         fi
+      elif [[ $path != */.mix/* && $path != *"elm-stuff"* && ! -d $path ]]; then
+        echo $path
+        clear_screen
+        run_last_cmd
       fi
       done
     }
@@ -199,8 +200,8 @@ watch() {
   POSITIONAL=()
   while [[ $# -gt 0 ]]
   do
+    last_run_cmd=":"
     key="$1"
-
 
     case $key in
       -d|--debug)

--- a/constant_testing
+++ b/constant_testing
@@ -110,9 +110,25 @@ clear_screen() {
   tput reset
 }
 
+elm_analyse() {
+  log_info "Let's see how non compliant your elm is mate..."
+  elm_analyse_cmd="yarn --cwd assets run elm-analyse"
+  log_info "Running: $elm_analyse_cmd"
+  output=`$elm_analyse_cmd`
+  result=$?
+  echo "$output"
+  if [[ $result != 0 ]]; then
+    log_failure "Your elm is totally non compliant. What is this amateur hour?"
+  else
+    log_success "Much like a million monkeys at a typewriter will eventually write Shakespeare, your elm has lucked its way to being compliant. You're the best..."
+  fi
+}
+
 watch() {
   clear_screen
-  if [ $FIXED_FILE ]; then
+  if [ $ELM_ANALYSE ]; then
+    elm_analyse
+  elif [ $FIXED_FILE ]; then
     if [[ "$test_path" = *.exs ]]; then
       log_info "I'll run this for you now so you can see how broken it is before you start hacking about"
       mix_test "$test_path"
@@ -120,7 +136,7 @@ watch() {
       log_info "I'll run this for you now so you can see how broken it is before you start hacking about"
       elm_make $test_path
     else
-      log_failure "I need an exs or Main.elm file to work mate..."
+      log_failure "I don't understand the arguement you gave me. Try again buddy..."
     fi
   else
     log_info "I'm going to watch you work... in a creepy way"
@@ -141,6 +157,8 @@ watch() {
           log_info "I'm watching you..."
           cd - > /dev/null
         fi
+      elif [[ $path == *.elm && $ELM_ANALYSE ]]; then
+        elm_analyse
       elif [[ $path == *.elm ]]; then
         clear_screen
         if [ $FIXED_FILE ]; then
@@ -163,9 +181,14 @@ watch() {
   do
     key="$1"
 
+
     case $key in
       -d|--debug)
         DEBUG=true
+        shift
+        ;;
+      -ea|--elm-analyse)
+        ELM_ANALYSE=true
         shift
         ;;
       -t|--test)

--- a/constant_testing
+++ b/constant_testing
@@ -102,11 +102,6 @@ clear_screen() {
   tput reset
 }
 
-elm_analyse() {
-  log_info "Let's see how non compliant your elm is mate..."
-  run_command "yarn --cwd assets run elm-analyse" "Much like a million monkeys at a typewriter will eventually write Shakespeare, your elm has lucked its way to being compliant. You're the best..." "Your elm is totally non compliant. What is this amateur hour?" true
-}
-
 elm_test() {
   run_command "yarn --cwd assets run elm-test" "Your elm tests passed! First time for everything..." "Your elm is riddled with bugs... (at least you have tests(s) though)..." true
 }
@@ -137,9 +132,7 @@ run_last_cmd() {
 
 watch() {
   clear_screen
-  if [ $ELM_ANALYSE ]; then
-    elm_analyse
-  elif [ $ELM_TEST ]; then
+  if [ $ELM_TEST ]; then
     elm_test
   elif [ $FIXED_FILE ]; then
     if [[ "$test_path" = *.exs* ]]; then
@@ -170,9 +163,6 @@ watch() {
           log_info "I'm watching you..."
           cd - > /dev/null
         fi
-      elif [[ $path == *.elm && $ELM_ANALYSE && $path != *"elm-stuff"* ]]; then
-        clear_screen
-        elm_analyse
       elif [[ $path == *.elm && $ELM_TEST && $path != *"elm-stuff"* ]]; then
         clear_screen
         elm_test
@@ -189,7 +179,6 @@ watch() {
           fi
         fi
       elif [[ $path != */.mix/* && $path != *"elm-stuff"* && ! -d $path ]]; then
-        echo $path
         clear_screen
         run_last_cmd
       fi
@@ -206,10 +195,6 @@ watch() {
     case $key in
       -d|--debug)
         DEBUG=true
-        shift
-        ;;
-      -ea|--elm-analyse)
-        ELM_ANALYSE=true
         shift
         ;;
       -et|--elm-test)

--- a/constant_testing
+++ b/constant_testing
@@ -126,7 +126,7 @@ elm_analyse() {
 
 elm_test() {
   log_info "Let's run the elm tests..."
-  elm_test_cmd="yarn --cwd assets run elm-test"
+  elm_test_cmd="yarn --cwd assets run elm-test-all"
   log_info "Running: $elm_test_cmd"
   output=`$elm_test_cmd`
   result=$?

--- a/constant_testing
+++ b/constant_testing
@@ -124,10 +124,26 @@ elm_analyse() {
   fi
 }
 
+elm_test() {
+  log_info "Let's run the elm tests..."
+  elm_test_cmd="yarn --cwd assets run elm-test"
+  log_info "Running: $elm_test_cmd"
+  output=`$elm_test_cmd`
+  result=$?
+  echo "$output"
+  if [[ $result != 0 ]]; then
+    log_failure "Your elm is riddled with bugs... (at least you have tests(s) though)..."
+  else
+    log_success "Your elm tests passed! First time for everything..."
+  fi
+}
+
 watch() {
   clear_screen
   if [ $ELM_ANALYSE ]; then
     elm_analyse
+  elif [ $ELM_TEST ]; then
+    elm_test
   elif [ $FIXED_FILE ]; then
     if [[ "$test_path" = *.exs ]]; then
       log_info "I'll run this for you now so you can see how broken it is before you start hacking about"
@@ -157,9 +173,13 @@ watch() {
           log_info "I'm watching you..."
           cd - > /dev/null
         fi
-      elif [[ $path == *.elm && $ELM_ANALYSE ]]; then
+      elif [[ $path == *.elm && $ELM_ANALYSE && $path != *"elm-stuff"* ]]; then
+        clear_screen
         elm_analyse
-      elif [[ $path == *.elm ]]; then
+      elif [[ $path == *.elm && $ELM_TEST && $path != *"elm-stuff"* ]]; then
+        clear_screen
+        elm_test
+      elif [[ $path == *.elm && $path != *"elm-stuff"* ]]; then
         clear_screen
         if [ $FIXED_FILE ]; then
           elm_make $test_path
@@ -189,6 +209,10 @@ watch() {
         ;;
       -ea|--elm-analyse)
         ELM_ANALYSE=true
+        shift
+        ;;
+      -et|--elm-test)
+        ELM_TEST=true
         shift
         ;;
       -t|--test)

--- a/constant_testing
+++ b/constant_testing
@@ -127,7 +127,7 @@ run_command() {
 
 run_last_cmd() {
   log_info "I don't know what to do with the file you just saved, so I'll just run the last thing I did again..."
-  run_command "$last_run_cmd" "Looks like everything is ok?" "It totally wrecked..."
+  run_command "$last_run_cmd" "Looks like everything is ok?" "It totally wrecked..." true
 }
 
 watch() {

--- a/constant_testing
+++ b/constant_testing
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 mix_test() {
-  run_command "mix test $1 --color" "Congratulations, you haven't broken anything... yet..." "OOOPPPPSIE - Somewhat predictably, you've broken something"
+  run_command "mix test $1 --color" "Congratulations, you haven't broken anything... yet..." "OOOPPPPSIE - Somewhat predictably, you've broken something" true
 }
 
 log_info() {

--- a/constant_testing
+++ b/constant_testing
@@ -32,10 +32,28 @@ test_file_changed() {
 }
 
 elm_make() {
-  log_info "Running 'elm make $1'"
+  #TODO figure out why rerunning with rerun_last_command has messed up output
+  run_command "elm_make_from_correct_dir $1" "Congrats, elm actually compiles... for now" "Turns out your elm is totally broken... what a suprise.... to nobody" true "elm make $1"
+}
+
+elm_make_from_correct_dir() {
   make_dir=$(find_elm_json $1)
   pushd $make_dir > /dev/null
+  outout=`elm make $1 2>&1`
   elm make $1
+  popd > /dev/null
+  echo $output
+}
+
+elm_test_command() {
+  echo "elm-test"
+}
+
+elm_test() {
+  elm_json_path=$(find_first_elm_json)
+  elm_json_dir=$(dirname $elm_json_path)
+  pushd $elm_json_dir > /dev/null
+  run_command $(elm_test_command) "Your elm tests passed! First time for everything..." "Your elm is riddled with bugs... (at least you have tests(s) though)..." true
   popd > /dev/null
 }
 
@@ -50,7 +68,7 @@ find_elm_json() {
 }
 
 find_first_elm_json() {
-  echo `find -name elm.json -print -quit`
+  echo `find -name elm.json ! -path */elm-stuff/* -print -quit`
 }
 
 real_readlink() {
@@ -106,24 +124,17 @@ clear_screen() {
   tput reset
 }
 
-elm_test_command() {
-  echo "elm-test"
-}
-
-elm_test() {
-  elm_json_path=$(find_first_elm_json)
-  elm_json_dir=$(dirname $elm_json_path)
-  pushd $elm_json_dir > /dev/null
-  run_command $(elm_test_command) "Your elm tests passed! First time for everything..." "Your elm is riddled with bugs... (at least you have tests(s) though)..." true
-  popd > /dev/null
-}
-
 run_command() {
   cmd="$1"
   success_message="$2"
   failure_message="$3"
   echo_output=$4
-  log_info "Running: $cmd"
+  log_cmd=$5
+  if [[ $log_cmd = "" ]]; then
+    log_info "Running: $cmd"
+  else
+    log_info "Running: $log_cmd"
+  fi
   output=`$cmd`
   result=$?
   last_run_cmd=$cmd
@@ -195,7 +206,7 @@ watch() {
             log_info "No Main.elm found for $path"
           fi
         fi
-      elif [[ $path != */.mix/* && $path != *"elm-stuff"* && ! -d $path ]]; then
+      elif [[ $path != */.mix/* && $path != *"elm-stuff"* && ! -d $path && $path != *"elm/index.html" ]]; then
         clear_screen
         run_last_cmd
       fi

--- a/constant_testing
+++ b/constant_testing
@@ -126,7 +126,7 @@ elm_analyse() {
 
 elm_test() {
   log_info "Let's run the elm tests..."
-  elm_test_cmd="yarn --cwd assets run elm-test-all"
+  elm_test_cmd="yarn --cwd assets run elm-test"
   log_info "Running: $elm_test_cmd"
   output=`$elm_test_cmd`
   result=$?
@@ -145,7 +145,7 @@ watch() {
   elif [ $ELM_TEST ]; then
     elm_test
   elif [ $FIXED_FILE ]; then
-    if [[ "$test_path" = *.exs ]]; then
+    if [[ "$test_path" = *.exs* ]]; then
       log_info "I'll run this for you now so you can see how broken it is before you start hacking about"
       mix_test "$test_path"
     elif [[ "$test_path" = *Main.elm ]]; then


### PR DESCRIPTION
Adding an `-et` / `--elm-test` option that will run `elm-test`
when any `*.elm` file is saved.

**Also**

Added a feature where if the last file saved is not a recognised extension, then contant_testing will re-run the last command. Helpful if you jump to some other file which indirectly effects the test you were just writing, and you want to see what effect saving this other file has on your test.