### PR TITLE
Use python3 instead of system default

### DIFF
--- a/constant_testing
+++ b/constant_testing
@@ -58,7 +58,7 @@ find_elm_json() {
 }
 
 real_readlink() {
-  python -c "import os,sys;print os.path.realpath(\"$1\")"
+  python3 -c "import os,sys;print(os.path.realpath(\"$1\"))"
 }
 
 find_file_in_parent() {


### PR DESCRIPTION
The `python` command defaults to python3 on my machine and many other distros are following suit. Python3 changed the syntax for print so didn't work on my machine.