### PR TITLE
Remove broken "run last command" feature & fixes wrong output when elm make fails

### DIFF
--- a/constant_testing
+++ b/constant_testing
@@ -31,8 +31,6 @@ test_file_changed() {
   fi
 }
 
-  #TODO if the saved path is in test/ then run elm test instead! great idea
-  #TODO write tests for constant testing you oaf!
 elm_make() {
   run_command "elm_make_from_correct_dir $1" "Congrats, elm actually compiles... for now" "Turns out your elm is totally broken... what a surprise.... to nobody" true "elm make $1"
 }

--- a/constant_testing
+++ b/constant_testing
@@ -49,8 +49,6 @@ find_elm_main_path_relative_to_elm_json() {
   current_dir="$(pwd)"
   main_file_path=$1
 
-  str="Learn to Split a String in Bash Scripting"
-
   IFS='/'
   current_dir_heirarchy=()
   read -ra ADDR <<< "$current_dir"

--- a/constant_testing
+++ b/constant_testing
@@ -33,16 +33,15 @@ test_file_changed() {
 
 elm_make() {
   #TODO figure out why rerunning with rerun_last_command has messed up output
+  echo "I'm about to run elm make!"
   run_command "elm_make_from_correct_dir $1" "Congrats, elm actually compiles... for now" "Turns out your elm is totally broken... what a suprise.... to nobody" true "elm make $1"
 }
 
 elm_make_from_correct_dir() {
   make_dir=$(find_elm_json $1)
   pushd $make_dir > /dev/null
-  outout=`elm make $1 2>&1`
   elm make $1
   popd > /dev/null
-  echo $output
 }
 
 elm_test_command() {
@@ -121,10 +120,12 @@ mix_path() {
 
 
 clear_screen() {
-  tput reset
+  #tput reset
+  echo "screen cleared! (not really)"
 }
 
 run_command() {
+  echo "*** About to run a command ***"
   cmd="$1"
   success_message="$2"
   failure_message="$3"
@@ -135,12 +136,13 @@ run_command() {
   else
     log_info "Running: $log_cmd"
   fi
+  echo "the command will be ($cmd)"
   output=`$cmd`
   result=$?
   last_run_cmd=$cmd
-  if [[ $echo_output = true ]]; then
-    echo "$output"
-  fi
+  #if [[ $echo_output = true ]]; then
+    echo "hello mother: $output"
+  #fi
   if [[ $result != 0 ]]; then
     log_failure "$failure_message"
   else
@@ -201,6 +203,7 @@ watch() {
         else
           main=$(find_main $path)
           if [ $? -eq 0 ]; then
+            echo "clear the screen. its elm time motherflipper"
             elm_make $main
           else
             log_info "No Main.elm found for $path"

--- a/constant_testing
+++ b/constant_testing
@@ -31,17 +31,19 @@ test_file_changed() {
   fi
 }
 
+  #TODO if the saved path is in test/ then run elm test instead! great idea
+  #TODO write tests for constant testing you oaf!
 elm_make() {
-  #TODO figure out why rerunning with rerun_last_command has messed up output
-  echo "I'm about to run elm make!"
-  run_command "elm_make_from_correct_dir $1" "Congrats, elm actually compiles... for now" "Turns out your elm is totally broken... what a suprise.... to nobody" true "elm make $1"
+  run_command "elm_make_from_correct_dir $1" "Congrats, elm actually compiles... for now" "Turns out your elm is totally broken... what a surprise.... to nobody" true "elm make $1"
 }
 
 elm_make_from_correct_dir() {
   make_dir=$(find_elm_json $1)
   pushd $make_dir > /dev/null
   elm make $1
+  result=$?
   popd > /dev/null
+  return $result
 }
 
 elm_test_command() {
@@ -120,12 +122,10 @@ mix_path() {
 
 
 clear_screen() {
-  #tput reset
-  echo "screen cleared! (not really)"
+  tput reset
 }
 
 run_command() {
-  echo "*** About to run a command ***"
   cmd="$1"
   success_message="$2"
   failure_message="$3"
@@ -136,27 +136,15 @@ run_command() {
   else
     log_info "Running: $log_cmd"
   fi
-  echo "the command will be ($cmd)"
   output=`$cmd`
   result=$?
-  last_run_cmd=$cmd
-  #if [[ $echo_output = true ]]; then
-    echo "hello mother: $output"
-  #fi
+  if [[ $echo_output = true ]]; then
+    echo "$output"
+  fi
   if [[ $result != 0 ]]; then
     log_failure "$failure_message"
   else
     log_success "$success_message"
-  fi
-}
-
-run_last_cmd() {
-  if [[ $last_run_cmd = $(elm_test_command) ]]; then
-    log_info "I don't know what to do with the file you just saved, so I'll just run the last thing I did again..."
-    elm_test
-  else
-    log_info "I don't know what to do with the file you just saved, so I'll just run the last thing I did again..."
-    run_command "$last_run_cmd" "Looks like everything is ok?" "It totally wrecked..." true
   fi
 }
 
@@ -203,15 +191,11 @@ watch() {
         else
           main=$(find_main $path)
           if [ $? -eq 0 ]; then
-            echo "clear the screen. its elm time motherflipper"
             elm_make $main
           else
             log_info "No Main.elm found for $path"
           fi
         fi
-      elif [[ $path != */.mix/* && $path != *"elm-stuff"* && ! -d $path && $path != *"elm/index.html" ]]; then
-        clear_screen
-        run_last_cmd
       fi
       done
     }
@@ -220,7 +204,6 @@ watch() {
   POSITIONAL=()
   while [[ $# -gt 0 ]]
   do
-    last_run_cmd=":"
     key="$1"
 
     case $key in

--- a/constant_testing
+++ b/constant_testing
@@ -38,14 +38,14 @@ elm_make() {
 elm_make_from_correct_dir() {
   make_dir=$(find_elm_json $1)
   pushd $make_dir > /dev/null
-  path=$(find_fixed_elm_main_path $1)
+  path=$(find_elm_main_path_relative_to_elm_json $1)
   elm make "$path"
   result=$?
   popd > /dev/null
   return $result
 }
 
-find_fixed_elm_main_path() {
+find_elm_main_path_relative_to_elm_json() {
   current_dir="$(pwd)"
   main_file_path=$1
 

--- a/constant_testing
+++ b/constant_testing
@@ -38,10 +38,58 @@ elm_make() {
 elm_make_from_correct_dir() {
   make_dir=$(find_elm_json $1)
   pushd $make_dir > /dev/null
-  elm make $1
+  path=$(find_fixed_elm_main_path $1)
+  elm make "$path"
   result=$?
   popd > /dev/null
   return $result
+}
+
+find_fixed_elm_main_path() {
+  current_dir="$(pwd)"
+  main_file_path=$1
+
+  str="Learn to Split a String in Bash Scripting"
+
+  IFS='/'
+  current_dir_heirarchy=()
+  read -ra ADDR <<< "$current_dir"
+  for i in "${ADDR[@]}"; do
+    current_dir_heirarchy+=("$i")
+  done
+
+  main_file_dir_heirarchy=()
+  read -ra ADDR <<< "$main_file_path"
+  for i in "${ADDR[@]}"; do
+      main_file_dir_heirarchy+=("$i")
+  done
+
+  looking_index=0
+
+  for i in "${current_dir_heirarchy[@]}"; do
+    if [[ "$i" = "${main_file_dir_heirarchy[$looking_index]}" ]]; then
+      looking_index=$(($looking_index + 1))
+      first_dir_after="$i"
+    elif (( $looking_index > 0 )); then
+      break;
+    fi
+  done
+
+  path=""
+  start_appending=false
+  for i in "${main_file_dir_heirarchy[@]}"; do
+    if [[ $start_appending = false ]]; then
+      if [[ $i = $first_dir_after ]]; then
+        start_appending=true
+      fi
+    else
+      path="${path}$i/"
+    fi
+  done
+
+  path="${path%?}"
+
+  echo "$path"
 }
 
 elm_test_command() {


### PR DESCRIPTION
The "run last command" feature I added which would

- run test X when /path/to/test/X is saved
- when /some/arbitrary/file/with/unknown/file/extenion.blah was saved, it would run `mix test /path/to/test/X` (or whatever the last thing it ran was

it was broken and added a lot of confusion to the code so i deleted it.

ALSO

I have fixed a problem where elm make wouldn't run because of an issue with relative file paths

ALSO

there was a problem where if `elm make` failed to compile, it would show a success message